### PR TITLE
NM-73 feat : Auth Recoil 전역 로직 추가

### DIFF
--- a/.github/workflows/Pull_Request_Lint.yml
+++ b/.github/workflows/Pull_Request_Lint.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
     environment: Test
 

--- a/micro_services/auth/src/components/LoginArea/KaKaoLoginButton.tsx
+++ b/micro_services/auth/src/components/LoginArea/KaKaoLoginButton.tsx
@@ -25,7 +25,7 @@ export default function KaKaoLoginButton() {
     setTimeout(() => {
       windowRef.current?.close();
       setLoading(false);
-    }, 1000);
+    }, 2000);
   });
 
   return (

--- a/micro_services/auth/src/pages/login/hooks/useKaKaoLogin.tsx
+++ b/micro_services/auth/src/pages/login/hooks/useKaKaoLogin.tsx
@@ -1,14 +1,19 @@
+import { useSetRecoilState } from 'recoil';
+
 import request from '@packages/utils/api/axios';
 import { getCookie, setCookie, removeCookie } from '@packages/utils/api/cookies';
 import getDateHour from '@packages/utils/getDateHour';
 
 import { LoginType } from 'auth/components/LoginArea/constant';
 
+import { authSelector } from 'auth/utils/recoil/auth';
+
 import { LoginStateType } from '..';
 
 interface IToken {
   accessToken: string;
   refreshToken: string;
+  usersId: string;
 }
 
 export default async function useKaKaoLogin(
@@ -16,6 +21,8 @@ export default async function useKaKaoLogin(
   type: LoginType,
   handleState: (props: LoginStateType) => void,
 ) {
+  const setAuthState = useSetRecoilState(authSelector);
+
   if (!code || getCookie('accessToken')) return;
   if (type !== 'kakao') return;
 
@@ -23,8 +30,11 @@ export default async function useKaKaoLogin(
     const result: IToken = await request.get(`oauth/kakao?code=${code}`);
 
     handleState('success');
+    setAuthState('user');
     removeCookie('accessToken');
     removeCookie('refreshToken');
+    localStorage.removeItem('usersId');
+
     setCookie({
       name: 'accessToken',
       value: result.accessToken,
@@ -35,6 +45,7 @@ export default async function useKaKaoLogin(
       value: result.refreshToken,
       options: { path: '/', expires: new Date(Date.now() + getDateHour(24 * 30)) },
     });
+    localStorage.setItem('usersId', result.usersId);
   } catch (err) {
     handleState('error');
   }

--- a/micro_services/auth/src/utils/recoil/auth.ts
+++ b/micro_services/auth/src/utils/recoil/auth.ts
@@ -1,0 +1,59 @@
+import { atom, selector } from 'recoil';
+
+import { getCookie } from '@packages/utils/api/cookies';
+import request from '@packages/utils/api/axios';
+
+import { IUser } from 'auth/utils/types/interface';
+
+type AuthType = 'visitor' | 'user';
+
+const authState = atom<AuthType>({
+  key: 'authState',
+  default: 'visitor',
+});
+
+const authInfoState = atom<IUser>({
+  key: 'authInfoState',
+  default: {
+    usersId: '',
+    nickname: '',
+    reviewScore: 0.0,
+    reviewCount: 0,
+    rentingCount: 0,
+    returningCount: 0,
+    buyCount: 0,
+    sellCount: 0,
+  },
+});
+
+export const authSelector = selector({
+  key: 'authSelector',
+  get: ({ get }) => {
+    const accessToken = getCookie('accessToken');
+    const tokenState = accessToken ? 'user' : 'visitor';
+    const currentState = get(authState);
+
+    return tokenState !== currentState ? tokenState : currentState;
+  },
+  set: ({ set }, newState) => {
+    set(authState, newState as AuthType);
+  },
+});
+
+export const authInfoSelector = selector({
+  key: 'authInfoSelector',
+  get: async ({ get }) => {
+    const state = get(authInfoState);
+    const usersId = localStorage.getItem('usersId');
+    const res = await request.get(`users/findUsers/${usersId}`);
+
+    if (res) {
+      return res;
+    }
+
+    return state;
+  },
+  set: ({ set }, newInfoState) => {
+    set(authInfoState, newInfoState as IUser);
+  },
+});

--- a/micro_services/auth/src/utils/types/interface.ts
+++ b/micro_services/auth/src/utils/types/interface.ts
@@ -1,0 +1,10 @@
+export interface IUser {
+  usersId: string;
+  nickname: string;
+  reviewScore: number;
+  reviewCount: number;
+  rentingCount: number;
+  returningCount: number;
+  buyCount: number;
+  sellCount: number;
+}

--- a/micro_services/auth/vite.config.ts
+++ b/micro_services/auth/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       filename: 'remoteEntry.js',
       exposes: {
         './components/LoginArea': './src/components/LoginArea',
+        './state/auth': './src/utils/recoil/auth',
       },
       shared: ['react', 'react-dom', 'react-router-dom', 'recoil'],
     }),

--- a/micro_services/host/vite.config.ts
+++ b/micro_services/host/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
         auth: `http://${PREFIX_ENVIRONMENT_URL('auth', 5001)}/assets/remoteEntry.js`,
         books: `http://${PREFIX_ENVIRONMENT_URL('books', 5002)}/assets/remoteEntry.js`,
       },
-      shared: ['react', 'react-dom', 'react-router-dom'],
+      shared: ['react', 'react-dom', 'react-router-dom', 'recoil'],
     }),
   ],
   resolve: {


### PR DESCRIPTION
# 🔨 지라 이슈
[NM-73]

# 📝 설명

- auth 관련 Recoil 전역 로직을 추가했습니다.
- host 모듈에서 받아 사용할 계획입니다.


[NM-73]: https://rfv1479.atlassian.net/browse/NM-73?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ