### PR TITLE
feat : Cookie Options 설정 및 Domain 변경

### DIFF
--- a/micro_services/auth/src/pages/login/hooks/useLogin.tsx
+++ b/micro_services/auth/src/pages/login/hooks/useLogin.tsx
@@ -37,12 +37,22 @@ export default function useLogin(
       setCookie({
         name: 'accessToken',
         value: result.accessToken,
-        options: { path: '/', expires: new Date(Date.now() + getDateHour(1)) },
+        options: {
+          domain: '.modolib.site',
+          secure: true,
+          path: '/',
+          expires: new Date(Date.now() + getDateHour(1)),
+        },
       });
       setCookie({
         name: 'refreshToken',
         value: result.refreshToken,
-        options: { path: '/', expires: new Date(Date.now() + getDateHour(24 * 30)) },
+        options: {
+          domain: '.modolib.site',
+          secure: true,
+          path: '/',
+          expires: new Date(Date.now() + getDateHour(24 * 30)),
+        },
       });
       localStorage.setItem('usersId', result.usersId);
       window.location.replace(`${import.meta.env.VITE_HOST_URL}/`);

--- a/micro_services/auth/src/pages/login/hooks/useLogin.tsx
+++ b/micro_services/auth/src/pages/login/hooks/useLogin.tsx
@@ -3,17 +3,12 @@ import { useSetRecoilState } from 'recoil';
 import request from '@packages/utils/api/axios';
 import { setCookie, removeCookie } from '@packages/utils/api/cookies';
 import getDateHour from '@packages/utils/getDateHour';
+import { IToken } from '@packages/utils/api/reIssueToken';
 
 import { LoginType } from 'auth/components/LoginArea/constant';
 
 import { LoadingStateType } from 'auth/utils/types';
 import { authSelector } from 'auth/utils/recoil/auth';
-
-interface IToken {
-  accessToken: string;
-  refreshToken: string;
-  usersId: string;
-}
 
 export default function useLogin(
   code: string | null,

--- a/micro_services/auth/src/utils/recoil/auth.ts
+++ b/micro_services/auth/src/utils/recoil/auth.ts
@@ -2,6 +2,7 @@ import { atom, selector } from 'recoil';
 
 import { getCookie } from '@packages/utils/api/cookies';
 import request from '@packages/utils/api/axios';
+import reIssueToken from '@packages/utils/api/reIssueToken';
 
 import { IUser } from 'auth/utils/types/interface';
 
@@ -28,15 +29,18 @@ const authInfoAtom = atom<IUser>({
 
 export const authSelector = selector({
   key: 'authSelector',
-  get: () => {
+  get: async () => {
     const accessToken = getCookie('accessToken');
     const refreshToken = getCookie('refreshToken');
-    const tokenState = accessToken ? 'user' : 'visitor';
 
-    if (refreshToken && tokenState === 'visitor') {
-      // TODO : refresh 토큰 발급
+    if (refreshToken && !accessToken) {
+      await reIssueToken(refreshToken);
+      const reAccessToken = getCookie('accessToken');
+      const reTokenState = reAccessToken ? 'user' : 'visitor';
+      return reTokenState;
     }
 
+    const tokenState = accessToken ? 'user' : 'visitor';
     return tokenState;
   },
   set: ({ set }, newAtom) => {

--- a/nginx.conf
+++ b/nginx.conf
@@ -15,9 +15,8 @@ server {
   }
 
   # server rewrites
-  location /api {
-    rewrite ^/api/?(.*) /$1 break;
-    add_header Access-Control-Allow-Origin *;
+  location /request {
+    rewrite ^/request/?(.*) /$1 break;
     proxy_pass https://modolib.com;
     proxy_redirect off;
     proxy_set_header Host $host;

--- a/nginx.conf
+++ b/nginx.conf
@@ -17,6 +17,7 @@ server {
   # server rewrites
   location /api {
     rewrite ^/api/?(.*) /$1 break;
+    add_header Access-Control-Allow-Origin *;
     proxy_pass https://modolib.com;
     proxy_redirect off;
     proxy_set_header Host $host;

--- a/packages/utils/api/reIssueToken.ts
+++ b/packages/utils/api/reIssueToken.ts
@@ -1,0 +1,42 @@
+import axios from 'axios';
+
+import getDateHour from '@packages/utils/getDateHour';
+
+import { setCookie, removeCookie } from './cookies';
+
+export interface IToken {
+  accessToken: string;
+  refreshToken: string;
+  usersId: string;
+}
+
+export default async function reIssueToken(refreshToken: string) {
+  const result: IToken = await axios.post(
+    'v1/auth/reIssue',
+    {},
+    { headers: { Token: `Bearer ${refreshToken}` } },
+  );
+
+  removeCookie('accessToken');
+  removeCookie('refreshToken');
+  setCookie({
+    name: 'accessToken',
+    value: result.accessToken,
+    options: {
+      domain: '.modolib.site',
+      secure: true,
+      path: '/',
+      expires: new Date(Date.now() + getDateHour(1)),
+    },
+  });
+  setCookie({
+    name: 'refreshToken',
+    value: result.refreshToken,
+    options: {
+      domain: '.modolib.site',
+      secure: true,
+      path: '/',
+      expires: new Date(Date.now() + getDateHour(24 * 30)),
+    },
+  });
+}


### PR DESCRIPTION
# 🔨 지라 이슈
- [NM-79]
- [NM-76]

# 📝 설명
- 쿠키 도메인이 서브도메인(`auth.modolib.site`)에 할당되어 다른 도메인에선 값을 읽어올 수 없는 문제를 해결하였습니다.
- `refreshToken` 자동 발급 후 재요청하는 기능을 추가하였습니다.

[NM-79]: https://rfv1479.atlassian.net/browse/NM-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NM-76]: https://rfv1479.atlassian.net/browse/NM-76?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ