### PR TITLE
NM-91 fix : reIssueToken 함수 오류 수정

### DIFF
--- a/packages/utils/api/reIssueToken.ts
+++ b/packages/utils/api/reIssueToken.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosResponse } from 'axios';
 
 import getDateHour from '@packages/utils/getDateHour';
 
@@ -11,22 +11,28 @@ export interface IToken {
 }
 
 export default async function reIssueToken(refreshToken: string) {
-  const result: IToken = await axios.post(
-    'v1/auth/reIssue',
-    {},
-    { headers: { Token: `Bearer ${refreshToken}` } },
-  );
-
-  removeCookie('accessToken');
-  removeCookie('refreshToken');
-  setCookie({
-    name: 'accessToken',
-    value: result.accessToken,
-    expired: getDateHour(0.5),
-  });
-  setCookie({
-    name: 'refreshToken',
-    value: result.refreshToken,
-    expired: getDateHour(6),
-  });
+  await axios
+    .post(
+      `${import.meta.env.VITE_SERVER_URL}/api/v1/auth/reIssue`,
+      {},
+      { headers: { Token: `Bearer ${refreshToken}` } },
+    )
+    .then((res: AxiosResponse<IToken>) => {
+      removeCookie('accessToken');
+      removeCookie('refreshToken');
+      setCookie({
+        name: 'accessToken',
+        value: res.data.accessToken,
+        expired: getDateHour(0.5),
+      });
+      setCookie({
+        name: 'refreshToken',
+        value: res.data.refreshToken,
+        expired: getDateHour(6),
+      });
+    })
+    .catch((err) => {
+      console.error(err);
+      window.location.replace(`${import.meta.env.VITE_HOST_URL}/account/login?state=token_expired`);
+    });
 }


### PR DESCRIPTION
# 🔨 지라 이슈
- [NM-91]


# 📝 설명
- `accessToken`이 없을 때 재발급되는 로직이 잘못되어 수정하였습니다.
- 경로 오류
- 에러 핸들링 없음

[NM-91]: https://rfv1479.atlassian.net/browse/NM-91?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ