### PR TITLE
NM-138 fix : `Cannot read properties of undefined (reading 'usersId')` 에러 해결

### DIFF
--- a/micro_services/auth/src/utils/recoil/auth.ts
+++ b/micro_services/auth/src/utils/recoil/auth.ts
@@ -2,6 +2,7 @@ import { atom, selector } from 'recoil';
 
 import { getCookie } from '@packages/utils/api/cookies';
 import request from '@packages/utils/api/axios';
+import APIErrorCapture from '@packages/utils/error/APIErrorCapture';
 
 import { IUser } from 'auth/utils/types/interface';
 
@@ -32,10 +33,11 @@ export const authInfoSelector = selector({
 
     if (authInfo.usersId === '') {
       const usersId = getCookie('usersId');
-      const res: IUser = await request.get(`v1/users/findUsers/${usersId}`);
-
-      if (res.usersId) {
+      try {
+        const res: IUser = await request.get(`v1/users/findUsers/${usersId}`);
         return res;
+      } catch (err) {
+        APIErrorCapture(err, 'authInfo', 'debug');
       }
     }
 


### PR DESCRIPTION
# 🔨 지라 이슈
- [NM-138]

# 📝 설명
- api 요청 try-catch 구문으로 감싸 Promise 단위의 데이터로 남지 않게끔 수정하였습니다.


[NM-138]: https://rfv1479.atlassian.net/browse/NM-138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ