### PR TITLE
Feat : Apple Login API Route

### DIFF
--- a/app/api/oauth/apple/callback/route.ts
+++ b/app/api/oauth/apple/callback/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { redirect } from 'next/navigation';
 import axios from 'axios';
 
-export async function POST(request: NextRequest) {
-  const res = await request.json();
-
-  const { code } = res.data.detail.authorization;
-  return NextResponse.redirect(`${request.url}/callback?code=${code || null}`, 302);
+export async function GET(request: NextRequest) {
+  const params = request.nextUrl.searchParams;
+  const code = params.get('code');
+  redirect(`${process.env.VITE_AUTH_URL}/login?code=${code}`);
 }
 
 export async function OPTIONS(request: Request) {

--- a/app/api/oauth/apple/callback/route.ts
+++ b/app/api/oauth/apple/callback/route.ts
@@ -1,11 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { redirect } from 'next/navigation';
-import axios from 'axios';
 
 export async function GET(request: NextRequest) {
   const params = request.nextUrl.searchParams;
   const code = params.get('code');
-  redirect(`${process.env.VITE_AUTH_URL}/login?code=${code}`);
+  return NextResponse.redirect(`${process.env.VITE_AUTH_URL}/login#code=${code}`, 302);
 }
 
 export async function OPTIONS(request: Request) {

--- a/app/api/oauth/apple/route.ts
+++ b/app/api/oauth/apple/route.ts
@@ -1,11 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
-import axios from 'axios';
 
 export async function POST(request: NextRequest) {
   const res = await request.json();
 
-  const { code } = res.data.detail.authorization;
-  return NextResponse.redirect(`${request.url}/callback?code=${code || null}`, 302);
+  if (res?.data?.detail?.authorization) {
+    const { code } = res.data.detail.authorization;
+    return NextResponse.redirect(`${request.url}/callback?code=${code}`, 302);
+  }
+  return NextResponse.redirect(`${request.url}/callback?code=null`, 302);
 }
 
 export async function OPTIONS(request: Request) {


### PR DESCRIPTION
# 🔨 지라 이슈
- [NM-124]


# 📝 설명
- Web Next.js단에 내부 API Route를 설정하였습니다.
- `api/oauth/apple`로 post 요청을 보내면, `api/oauth/apple/callback`에서 값을 판단 후 `auth.modolib.site/login`으로 GET Redirect 시킵니다.


[NM-124]: https://rfv1479.atlassian.net/browse/NM-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ