### PR TITLE
Feat : Next.js API Route로 애플 로그인 post 응답

### DIFF
--- a/app/api/oauth/apple/route.ts
+++ b/app/api/oauth/apple/route.ts
@@ -4,7 +4,10 @@ export async function POST(request: NextRequest) {
   const formData = await request.formData();
   const code = formData.get('code');
 
-  return NextResponse.redirect(`${request.url}/callback?code=${code}`, 302);
+  return NextResponse.redirect(
+    `https://www.modolib.site/api/oauth/apple/callback?code=${code}`,
+    302,
+  );
 }
 
 export async function OPTIONS(request: Request) {

--- a/app/api/oauth/apple/route.ts
+++ b/app/api/oauth/apple/route.ts
@@ -1,13 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function POST(request: NextRequest) {
-  const res = await request.json();
+  const formData = await request.formData();
+  const code = formData.get('code');
 
-  if (res?.data?.detail?.authorization) {
-    const { code } = res.data.detail.authorization;
-    return NextResponse.redirect(`${request.url}/callback?code=${code}`, 302);
-  }
-  return NextResponse.redirect(`${request.url}/callback?code=null`, 302);
+  return NextResponse.redirect(`${request.url}/callback?code=${code}`, 302);
 }
 
 export async function OPTIONS(request: Request) {


### PR DESCRIPTION
# 🔨 지라 이슈
- [NM-124]

# 📝 설명
- 애플 로그인 때 `redirect_uri`를 Next.js로 받아 `code` 값만 `formData`에서 Parsing 후 서버에 전송하는 로직을 추가하였습니다.

[NM-124]: https://rfv1479.atlassian.net/browse/NM-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ